### PR TITLE
fix the http/https redirect issue

### DIFF
--- a/services/passport.js
+++ b/services/passport.js
@@ -72,6 +72,7 @@ passport.use(
     clientSecret: facebookClientSecret,
     callbackURL: '/auth/facebook/callback',
     profileFields: ['id', 'email', 'photos'],
+    proxy: true, // required for heroku
   },
   async (accessToken, refreshToken, profile, done) => {
     const user = await User.findOne({ 'facebook.id': profile.id });


### PR DESCRIPTION
# Description

heroku is terminating HTTPS and routing to the app via HTTP, but that's causing the facebook redirect to redirect as HTTP which FB doesn't like.
![image](https://user-images.githubusercontent.com/7364664/130309859-8adfcbe5-7f36-496e-b015-abe9400985d3.png)

We need to set `proxy: true` field 

# Testing

no testing. yolo